### PR TITLE
Remove `base` element from HTML

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,6 @@
 
     {{ partial "meta.html" . }}
 
-    <base href="{{ .Site.BaseURL }}" />
     <title>{{ .Site.Title }}</title>
     <link rel="canonical" href="{{ .Permalink }}" />
     <link

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,6 @@
 
     {{ partial "meta.html" . }}
 
-    <base href="{{ .Site.BaseURL }}" />
     <title>{{ .Title }}</title>
     <link rel="canonical" href="{{ .Permalink }}" />
 


### PR DESCRIPTION
Hi!

When I opened #1 it surprised me the solution involved replacing some of the default HTML to make it have the page permalink. This shouldn't be necessary, AFAIK, in a normal use of a ToC, where it would be displayed inside a post page and the relative links should point to the very same page. So I removed that `replace` code, and got surprised when the links pointed to the root of my blog instead of inside the current page. Then I noticed something similar happened with footnotes.

I started digging around and found https://github.com/gohugoio/hugo/issues/811#issuecomment-101672627, where they discuss a similar problem and the given solution is to remove any `<base href="..." />` element of the theme HTML.

I did that in my local copy of the theme and it works as expected, both ToC and footnotes now correctly point to the current page.

Thanks for your work on this theme, BTW! 😄 