### PR TITLE
update highlightjs

### DIFF
--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -7,7 +7,7 @@
 
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/highlightjs@9.12.0/styles/github-gist.css"
+  href="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.16.2/build/styles/monokai.min.css"
 />
 
 {{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,4 +1,4 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.14.2/highlight.min.js"></script>
+<script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.16.2/build/highlight.min.js"></script>
 
 <script>
   hljs.initHighlightingOnLoad();


### PR DESCRIPTION
**What's the issue?**

- hugo-theme-basic pulls in highlightjs `9.12.0`.  The newer version seems to support different languages.

**How does this fix it?**

- Pulls in `9.16.2`.